### PR TITLE
Always use the first window as the presentation anchor.

### DIFF
--- a/Auth0/MobileWebAuth.swift
+++ b/Auth0/MobileWebAuth.swift
@@ -326,7 +326,7 @@ extension SFAuthenticationSession: AuthSession {}
 extension AuthenticationServicesSession: ASWebAuthenticationPresentationContextProviding {
 
     func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
-        return UIApplication.shared()?.windows.filter({ $0.isKeyWindow }).last ?? ASPresentationAnchor()
+        return UIApplication.shared()?.windows.first ?? ASPresentationAnchor()
     }
 
 }
@@ -335,7 +335,7 @@ extension AuthenticationServicesSession: ASWebAuthenticationPresentationContextP
 extension AuthenticationServicesSessionCallback: ASWebAuthenticationPresentationContextProviding {
 
     func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
-        return UIApplication.shared()?.windows.filter({ $0.isKeyWindow }).last ?? ASPresentationAnchor()
+        return UIApplication.shared()?.windows.first ?? ASPresentationAnchor()
     }
 
 }


### PR DESCRIPTION
We currently have an issue open in the Auth0 repo related to the window that is being used to present the authentication session (https://github.com/auth0/Auth0.swift/issues/435). To reduce risk I decided to make a fork and apply an easy fix while we await progress on the issue.